### PR TITLE
Fix options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,6 @@
 AC_PREREQ([2.69])
-AC_INIT([aspeed-lpc-ctrl], 0.2)
+AC_INIT([aspeed-lpc-ctrl],
+        [m4_esyscmd_s([git describe --always --dirty --long])])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([-Wall foreign dist-xz])
 AM_SILENT_RULES([yes])

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.69])
 AC_INIT([aspeed-lpc-ctrl],
-        [m4_esyscmd_s([git describe --always --dirty --long])])
+        [m4_esyscmd_s([git describe --always --dirty --long 2>/dev/null || echo vUnknown])])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([-Wall foreign dist-xz])
 AM_SILENT_RULES([yes])

--- a/memboot.c
+++ b/memboot.c
@@ -42,10 +42,7 @@ int main(int argc, char **argv)
 	const char *file;
 	int rc, c;
 
-	do {
-		c = getopt_long(argc, argv, "f:vVh", options, NULL);
-		if (c == -1)
-			break;
+	while (-1 != (c = getopt_long(argc, argv, "f:vVh", options, NULL))) {
 		switch (c) {
 		case 'f':
 			file = optarg;
@@ -63,7 +60,7 @@ int main(int argc, char **argv)
 				return 0;
 			exit(EXIT_FAILURE);
 		};
-	} while (c != EOF);
+	}
 
 	if (!file) {
 		show_help(basename(argv[0]));


### PR DESCRIPTION
This patchset fixes option processing and also gets rid of hard-coded version.
However, even though memboot now doesn't bail out and pretends to process the options like this:

```
# memboot -v -f /tmp/vesnin-tot.pnor
No path set, using default /dev/aspeed-lpc-ctrl
Opening /dev/aspeed-lpc-ctrl
Getting buffer size...
Mapping in 0x04000000 bytes of /dev/aspeed-lpc-ctrl
Pointing HOST LPC bus at memory region 0x72fba000 of size 0x04000000
LPC address 0x0c000000
```

The host fails to boot from this setup. `pnorboot` works just fine.